### PR TITLE
[Feat]메모리 관리 기능 구현

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -34,7 +34,7 @@ enum vm_type {
 
 struct page_operations;
 struct thread;
-
+struct list frame_table;
 #define VM_TYPE(type) ((type) & 7)
 
 /* "페이지"의 표현.


### PR DESCRIPTION
## ✅ [Feat] 메모리 관리 기능 구현

### 요약
Pintos Project 3 - Virtual Memory 과제에서 다음과 같은 **메모리 관리 기능**을 구현했습니다:

- 사용자 공간 물리 프레임 할당 (`vm_get_frame`)
- 가상 주소에 대한 페이지 클레임 처리 (`vm_claim_page`, `vm_do_claim_page`)
- `frame_table` 리스트 초기화 (`vm_init`)

---

### 🔨 변경 사항

#### 📁 `pintos/include/vm/vm.h`
- 전역 `struct list frame_table` 선언 추가

#### 📁 `pintos/vm/vm.c`
- `vm_init()`: `frame_table` 리스트 초기화 (`list_init`)
- `vm_get_frame()` 구현:
  - `palloc_get_page(PAL_USER)`로 사용자 풀에서 페이지 할당
  - 실패 시 `PANIC("todo")`
  - 할당된 `kva`와 `frame->page = NULL` 설정
- `vm_claim_page()` 구현:
  - SPT에서 주어진 `va`에 대응하는 페이지를 찾은 후
  - `vm_do_claim_page()` 호출
- `vm_do_claim_page()` 구현:
  - `vm_get_frame()`으로 프레임 확보
  - `page`와 `frame` 연결
  - `pml4_set_page()`로 가상 주소와 물리 주소 매핑

---

### 🧪 테스트 및 확인 사항
- 현재는 프레임 할당 및 VA→PA 매핑까지 정상 동작
- 스왑 아웃 없이, 프레임 할당 실패 시 `PANIC("todo")` 발생 확인
- SPT 기반 페이지 탐색 및 연결 구조 동작 테스트됨

---

### 📝 추가 참고 사항
- `frame_table`은 초기화만 되어 있으며, 아직 eviction 등에서 사용되지 않음
- `spt_find_page()`는 현재 임시 구현 상태이며 추후 수정 필요
- swap-out 및 eviction 구현은 이후 단계에서 반영 예정